### PR TITLE
Fix the packer install command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,13 @@
 
 Maybe necessary to use `--head` version in brew of neovim.
 
-Run `git clone https://github.com/wbthomason/packer.nvim\
- ~/.local/share/nvim/site/pack/packer/start/packer.nvim`
+Run
+
+```shell
+git clone --depth 1 https://github.com/wbthomason/packer.nvim\
+ ~/.local/share/nvim/site/pack/packer/start/packer.nvim
+```
+
  to install packer.
 
  Run `:CocInstall coc-json coc-tsserver` otherwise nvim may hang while quitting.


### PR DESCRIPTION
When copying the packer clone command, it does not work:

```
Cloning into 'packer.nvim'...
fatal: unable to access 'https://github.com/wbthomason/packer.nvim ~/.local/share/nvim/site/pack/packer/start/packer.nvim/': The requested URL returned error: 400
```

Either removing the `\` would work or providing the same formatting as the [readme](https://github.com/wbthomason/packer.nvim/blob/master/README.md) of packer.